### PR TITLE
feat: migrate to webdriverio@7

### DIFF
--- a/lib/conditions/assert-view-failed/index.js
+++ b/lib/conditions/assert-view-failed/index.js
@@ -4,21 +4,21 @@ const debug = require('debug')('hermione-retry-command:assert-view-failed');
 const Promise = require('bluebird');
 
 module.exports = (browser, {retryCount, retryInterval, retryOnlyFirst}) => {
-    const originAssertView = browser.assertView.bind(browser);
+    browser.overwriteCommand('assertView', assertViewWrap);
 
-    browser.addCommand('assertView', async function(...args) {
+    async function assertViewWrap(originAssertView, ...args) {
         let retriesLeft = retryCount;
         let result;
 
-        if (retryOnlyFirst && this.executionContext.hasCalledAssertView) {
+        if (retryOnlyFirst && browser.executionContext.hasCalledAssertView) {
             return await originAssertView(...args);
         }
 
-        this.executionContext.hasCalledAssertView = true;
+        browser.executionContext.hasCalledAssertView = true;
 
         result = await originAssertView(...args);
 
-        const hermioneCtx = this.executionContext.hermioneCtx;
+        const hermioneCtx = browser.executionContext.hermioneCtx;
         let assertViewResults = hermioneCtx.assertViewResults.get();
         let resultsLength = assertViewResults.length;
         let lastResult = assertViewResults[resultsLength - 1] || {};
@@ -50,5 +50,5 @@ module.exports = (browser, {retryCount, retryInterval, retryOnlyFirst}) => {
         }
 
         return result;
-    }, true);
+    }
 };

--- a/lib/conditions/assert-view-failed/index.js
+++ b/lib/conditions/assert-view-failed/index.js
@@ -5,6 +5,7 @@ const Promise = require('bluebird');
 
 module.exports = (browser, {retryCount, retryInterval, retryOnlyFirst}) => {
     browser.overwriteCommand('assertView', assertViewWrap);
+    browser.overwriteCommand('assertView', assertViewWrap, true);
 
     async function assertViewWrap(originAssertView, ...args) {
         let retriesLeft = retryCount;

--- a/lib/conditions/blank-screenshot/index.js
+++ b/lib/conditions/blank-screenshot/index.js
@@ -4,25 +4,21 @@ const debug = require('debug')('hermione-retry-command:blank-screenshot');
 const Promise = require('bluebird');
 
 const utils = require('./utils');
-const commonUtils = require('../../utils');
 
 module.exports = (browser, {retryCount, retryInterval}) => {
-    const isWdioLatest = commonUtils.isWdioLatest(browser);
-    const commandName = isWdioLatest ? 'takeScreenshot' : 'screenshot';
-    const originScreenshot = browser[commandName].bind(browser);
+    browser.overwriteCommand('takeScreenshot', screenshotWithRetries);
 
-    const screenshotWithRetries = async () => {
+    async function screenshotWithRetries(originTakeScreenshotFn) {
         let retriesLeft = retryCount;
         let base64;
 
         try {
-            base64 = await originScreenshot();
+            base64 = await originTakeScreenshotFn();
         } catch (e) {
             throw e;
         }
 
-        const strBase64 = isWdioLatest ? base64 : base64.value;
-        while (retriesLeft && utils.isBlankScreenshot(strBase64)) {
+        while (retriesLeft && utils.isBlankScreenshot(base64)) {
             await Promise.delay(retryInterval);
 
             debug(`Retrying #${retryCount - retriesLeft + 1} blank screenshot in ${retryInterval} ms`);
@@ -30,7 +26,7 @@ module.exports = (browser, {retryCount, retryInterval}) => {
             retriesLeft -= 1;
 
             try {
-                base64 = await originScreenshot();
+                base64 = await originTakeScreenshotFn();
             } catch (e) {
                 retriesLeft = 0;
 
@@ -39,7 +35,5 @@ module.exports = (browser, {retryCount, retryInterval}) => {
         }
 
         return base64;
-    };
-
-    browser.addCommand(commandName, () => screenshotWithRetries(), true);
+    }
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -7,5 +7,3 @@ const isMatched = (matcher, value) => _.isRegExp(matcher) ? matcher.test(value) 
 exports.isParamIncluded = (paramMatchers, param) => {
     return _.some([].concat(paramMatchers), (paramMatcher) => isMatched(paramMatcher, param));
 };
-
-exports.isWdioLatest = (browser) => Boolean(browser.overwriteCommand);

--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
     "lodash": "^4.17.11"
   },
   "peerDependencies": {
-    "hermione": ">=4.0.0"
+    "hermione": ">=5.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,5 +35,8 @@
     "debug": "^4.1.0",
     "gemini-configparser": "^1.0.0",
     "lodash": "^4.17.11"
+  },
+  "peerDependencies": {
+    "hermione": ">=4.0.0"
   }
 }

--- a/test/lib/conditions/blank-screenshot/index.js
+++ b/test/lib/conditions/blank-screenshot/index.js
@@ -19,7 +19,8 @@ describe('blank-screenshot', () => {
             takeScreenshot: sinon.stub().resolves('base64')
         };
 
-        browser.overwriteCommand = sinon.stub().callsFake((name, command) => {
+        browser.overwriteCommand = sinon.stub();
+        browser.overwriteCommand.withArgs(sinon.match.string, sinon.match.func).callsFake((name, command) => {
             browser[name] = command.bind(browser, browser[name]);
             sinon.spy(browser, name);
         });

--- a/test/lib/utils.js
+++ b/test/lib/utils.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const {isParamIncluded, isWdioLatest} = require('../../lib/utils');
+const {isParamIncluded} = require('../../lib/utils');
 
 describe('utils/isParamIncluded', () => {
     it('should allow to pass matcher as a string', () => {
@@ -40,20 +40,6 @@ describe('utils/isParamIncluded', () => {
             const result = isParamIncluded(['foo', 'bar'], '');
 
             assert.isFalse(result);
-        });
-    });
-
-    describe('isWdioLatest', () => {
-        it('should return "true" if "overwriteCommand" method is exists', () => {
-            const browser = {overwriteCommand: () => {}};
-
-            assert.isTrue(isWdioLatest(browser));
-        });
-
-        it('should return "false" if "overwriteCommand" method is not exists', () => {
-            const browser = {};
-
-            assert.isFalse(isWdioLatest(browser));
         });
     });
 });


### PR DESCRIPTION
BREAKING CHANGE: drop support for hermione@3

Also, added support for future hermione's element.assertView